### PR TITLE
Make electric meter entity compatible with energy dashboard

### DIFF
--- a/SDRMR/run.sh
+++ b/SDRMR/run.sh
@@ -63,7 +63,7 @@ function scmplus_parse {
   if is_gas $EPT; then
     RESTDATA=$( jq -nrc --arg state "$FIXED_STATE" --arg uid "$scmUID" --arg uom "$GUOM" '{"state": $state, "attributes": {"unique_id": $uid, "state_class": "total_increasing", "device_class": "gas",  "unit_of_measurement": $uom }}')
   elif is_electric $EPT; then
-    RESTDATA=$( jq -nrc --arg state "$STATE" --arg uid "$scmUID" --arg uom "$EUOM" '{"state": $state, "attributes": {"unique_id": $uid, "device_class": "energy", "unit_of_measurement": $uom, "state_class": "total" }}')
+    RESTDATA=$( jq -nrc --arg state "$STATE" --arg uid "$scmUID" --arg uom "$EUOM" '{"state": $state, "attributes": {"unique_id": $uid, "device_class": "energy", "unit_of_measurement": $uom, "state_class": "total_increasing" }}')
   elif is_water $EPT; then
     RESTDATA=$( jq -nrc --arg state "$STATE" --arg uid "$scmUID" --arg uom "$WUOM"'{"state": $state, "attributes": {"unique_id": $uid}, "unit_of_measurement": $uom }')
   else

--- a/SDRMR/run.sh
+++ b/SDRMR/run.sh
@@ -63,7 +63,7 @@ function scmplus_parse {
   if is_gas $EPT; then
     RESTDATA=$( jq -nrc --arg state "$FIXED_STATE" --arg uid "$scmUID" --arg uom "$GUOM" '{"state": $state, "attributes": {"unique_id": $uid, "state_class": "total_increasing", "device_class": "gas",  "unit_of_measurement": $uom }}')
   elif is_electric $EPT; then
-    RESTDATA=$( jq -nrc --arg state "$STATE" --arg uid "$scmUID" --arg uom "$EUOM" '{"state": $state, "attributes": {"unique_id": $uid, "device_class": "energy", "unit_of_measurement": $uom }}')
+    RESTDATA=$( jq -nrc --arg state "$STATE" --arg uid "$scmUID" --arg uom "$EUOM" '{"state": $state, "attributes": {"unique_id": $uid, "device_class": "energy", "unit_of_measurement": $uom, "state_class": "total" }}')
   elif is_water $EPT; then
     RESTDATA=$( jq -nrc --arg state "$STATE" --arg uid "$scmUID" --arg uom "$WUOM"'{"state": $state, "attributes": {"unique_id": $uid}, "unit_of_measurement": $uom }')
   else


### PR DESCRIPTION
Added `state_class: total_increasing` attribute to output for electric entity. This enables it to recognized as a compatible entity by the energy dashboard.