### PR TITLE
Added multiplier options and removed redundant options

### DIFF
--- a/SDRMR/CHANGELOG.md
+++ b/SDRMR/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.8.37] - 2022-12-25
+### Changes
+ - Implemented multipliers for each utility type
+ - Removed water tenths and gas divisor options due to redundancy
+
 ## [0.8.36] - 2022-12-23
 ### Changes
  - Added device class SCM+ water JSON output

--- a/SDRMR/README.md
+++ b/SDRMR/README.md
@@ -17,6 +17,8 @@ A hass.io addon for a software defined radio tuned to listen for Utility Meter R
     - msgType (RTLAMR Message type; see below)
     - ids* (IDs of the sensors you want to watch)
     - pause_time (Time between Readings in seconds)
+    - *_unit_of_measurement (The unit appended to the output)
+    - *_multiplier (value read from meter is multiplied by this)
 
 3) Start the addon
 
@@ -31,6 +33,13 @@ The following message types are supported by rtlamr:
 - **r900**: Message type used by Neptune R900 transmitters, provides total consumption and leak flags.
 - **r900bcd**: Some Neptune R900 meters report consumption as a binary-coded digits.
 - **all**: Listen for ALL of the above message types
+
+### Multipliers
+
+Some meters report in units that are not compatible with the HA energy dashboard. Multipliers can be set for each meter type so that meter readings can be converted to a compatible unit of measure. Here are a few examples of usage:
+
+- Some water meters report usage in 10ths of a gallon. To correct the reading, set water_multiplier = 0.1.
+- If your meter reports in CCF (centi cubic feet), you can set the multiplier to 748.1 to conver to gallons. Then select gal for the unit of measure.
 
 ## Hardware
 

--- a/SDRMR/config.yaml
+++ b/SDRMR/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: SDR Meter Reader
-version: 0.8.36
+version: 0.8.37
 slug: sdrmr
 description: RF to Home Assistant REST API Bridge based on RTL_SDR/RTL_433 for RTL2832U based DVB-T USB tuners
 startup: application
@@ -20,6 +20,7 @@ arch:
   - amd64
   - armv7
   - i386
+  
 options:
   debug: False
   rtltcpdebug: False
@@ -30,9 +31,10 @@ options:
   gas_unit_of_measurement: ft³
   electric_unit_of_measurement: kWh
   water_unit_of_measurement: gal
-  water_use_tenths: False
+  gas_multiplier: 1
+  electric_multiplier: 1
+  water_multiplier: 1
 
-  scm_plus_gas_divisor: 1
 schema:
   debug: bool
   rtltcpdebug: bool
@@ -43,7 +45,6 @@ schema:
   gas_unit_of_measurement: list(ft³|m³)
   electric_unit_of_measurement: list(Wh|kWh|MWh)
   water_unit_of_measurement: list(gal|l)
-  water_use_tenths: bool
-  scm_plus_gas_divisor: int?
-
-
+  gas_multiplier: float
+  electric_multiplier: float
+  water_multiplier: float


### PR DESCRIPTION
WARNING - This will break current configurations that use the gas divisor or water tenths options.

This PR will add a multiplier to the output of each utility type. The multiple serves as a translation between the units read from the utility meter and the units output to the HA rest api. This is a potential solution for issue #17 where the reading in CCF from the utility meter can be multiplied by 2.83 to convert it to m^3. Any units provided by a utility meter can be converted to a unit that can be handled by the HA energy dashboard.

We can also achieve the same results as the gas divisor option and water tenths option by multiplying by a decimal therefore these options are no longer needed.