### PR TITLE
Add m³ units. Water as default for r900. Symbol length to reduce cpu usage. Msg type input user friendly.

### DIFF
--- a/SDRMR/config.yaml
+++ b/SDRMR/config.yaml
@@ -24,13 +24,14 @@ arch:
 options:
   debug: False
   rtltcpdebug: False
-  msgType: scm
+  msgType: ""
   ids: ""
   duration: 15
   pause_time: 30
+  rtlamr_symbol_length: 72
   gas_unit_of_measurement: ft³
   electric_unit_of_measurement: kWh
-  water_unit_of_measurement: gal
+  water_unit_of_measurement: m³
   gas_multiplier: 1
   electric_multiplier: 1
   water_multiplier: 1
@@ -38,13 +39,14 @@ options:
 schema:
   debug: bool
   rtltcpdebug: bool
-  msgType: list(scm|scm+|scm+,r900|idm|netidm|r900|r900bcd|all)
+  msgType: str?
   ids: str?
   duration: int
   pause_time: int
+  rtlamr_symbol_length: list(8|32|40|48|56|64|72|80|88|96)
   gas_unit_of_measurement: list(ft³|m³)
   electric_unit_of_measurement: list(Wh|kWh|MWh)
-  water_unit_of_measurement: list(gal|l)
+  water_unit_of_measurement: list(gal|l|m³)
   gas_multiplier: float
   electric_multiplier: float
   water_multiplier: float

--- a/SDRMR/run.sh
+++ b/SDRMR/run.sh
@@ -145,12 +145,10 @@ function postto {
 
 # Set flags if variables are set
 x=""
+y="-symbollength=$AMR_SYMBOL"
+
 if [ ! -z "$AMR_IDS" ]; then
   x="-filterid=$AMR_IDS"
-fi
-
-if [[ "$AMR_SYMBOL" != "0" ]]; then
-  x="-symbollength=$AMR_SYMBOL"
 fi
 
 if [[ "$DURATION" != "0" ]]; then
@@ -160,7 +158,7 @@ fi
 
 # Function, runs a rtlamr listen event
 function listener {
-  /go/bin/rtlamr -format json -msgtype=$AMR_MSGTYPE $x| while read line
+  /go/bin/rtlamr -format json -msgtype=$AMR_MSGTYPE $x $y| while read line
   do
     postto
   done

--- a/SDRMR/run.sh
+++ b/SDRMR/run.sh
@@ -14,6 +14,7 @@ AMR_MSGTYPE="$(jq --raw-output '.msgType' $CONFIG_PATH)"
 AMR_IDS="$(jq --raw-output '.ids' $CONFIG_PATH)"
 DURATION="$(jq --raw-output '.duration' $CONFIG_PATH)"
 PT="$(jq --raw-output '.pause_time' $CONFIG_PATH)"
+AMR_SYMBOL="$(jq --raw-output '.rtlamr_symbol_length' $CONFIG_PATH)"
 GUOM="$(jq --raw-output '.gas_unit_of_measurement' $CONFIG_PATH)"
 EUOM="$(jq --raw-output '.electric_unit_of_measurement' $CONFIG_PATH)"
 WUOM="$(jq --raw-output '.water_unit_of_measurement' $CONFIG_PATH)"
@@ -28,6 +29,7 @@ echo "AMR Message Type =" $AMR_MSGTYPE
 echo "AMR Device IDs =" $AMR_IDS
 echo "Time Between Readings =" $PT
 echo "Duration = " $DURATION
+echo "Symbol length in samples =" $AMR_SYMBOL
 echo "Electric Unit of measurement = " $EUOM
 echo "Gas Unit of measurement = " $GUOM
 echo "Water Unit of measurement = " $WUOM
@@ -103,7 +105,8 @@ function r900_parse {
   --arg unkn1 "$UNKN1" \
   --arg unkn3 "$UNKN3" \
   --arg nouse "$NOUSE" \
-  '{"state": $st, "extra_state_attributes": {"unique_id": $uid}, "attributes": { "entity_id": $uid, "state_class": "total_increasing", "unit_of_measurement": "gal", "leak": $le, "leak_now": $ln, "BackFlow": $bf, "NoUse": $nouse, "Unknown1": $unkn1, "Unknown3": $unkn3 }}')
+  --arg uom "$WUOM" \
+  '{"state": $st, "extra_state_attributes": {"unique_id": $uid}, "attributes": { "entity_id": $uid, "device_class": "water", "state_class": "total_increasing", "unit_of_measurement": $uom, "leak": $le, "leak_now": $ln, "BackFlow": $bf, "NoUse": $nouse, "Unknown1": $unkn1, "Unknown3": $unkn3 }}')
 }
 
 # Function, posts data to home assistant that is gathered by the rtlamr script
@@ -146,9 +149,15 @@ if [ ! -z "$AMR_IDS" ]; then
   x="-filterid=$AMR_IDS"
 fi
 
+if [[ "$AMR_SYMBOL" != "0" ]]; then
+  x="-symbollength=$AMR_SYMBOL"
+fi
+
 if [[ "$DURATION" != "0" ]]; then
   x="$x -duration=${DURATION}s"
 fi
+
+
 # Function, runs a rtlamr listen event
 function listener {
   /go/bin/rtlamr -format json -msgtype=$AMR_MSGTYPE $x| while read line


### PR DESCRIPTION
I've added options for metric users (m³).
Made the msg type input more user friendly.
Added symbol length to lower cpu usage.
Added water device class to r900 by default.